### PR TITLE
(New feature) gpt4をプラグインから使用する機能 - use_gpt4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.plugin
 .venv
 env/
 venv/

--- a/src/autogpt_plugins/gpt4/.env.plugin.template
+++ b/src/autogpt_plugins/gpt4/.env.plugin.template
@@ -1,0 +1,3 @@
+# this is here because API key will hit rate limits with heavy use. you can change the key for this plugin.
+OPENAI_API_KEY = 
+GPT_MODEL =

--- a/src/autogpt_plugins/gpt4/.env.plugin.template
+++ b/src/autogpt_plugins/gpt4/.env.plugin.template
@@ -1,3 +1,0 @@
-# this is here because API key will hit rate limits with heavy use. you can change the key for this plugin.
-OPENAI_API_KEY = 
-GPT_MODEL =

--- a/src/autogpt_plugins/gpt4/README.md
+++ b/src/autogpt_plugins/gpt4/README.md
@@ -1,4 +1,11 @@
-# Plugin for PDF to Text
+# Plugin to use gpt4 as auto gpt command
+add this in .env file
+```
+## .env of use gpt4 plugin
+## this is here because API key will hit rate limits with heavy use. you can change the key for this plugin.
+OPENAI_API_KEY_PLUGIN = 
+GPT_MODEL_PLUGIN = gpt4
+```
 
 ## Features(more coming soon!)
 <!-- 

--- a/src/autogpt_plugins/gpt4/README.md
+++ b/src/autogpt_plugins/gpt4/README.md
@@ -8,10 +8,8 @@ GPT_MODEL_PLUGIN = gpt4
 ```
 
 ## Features(more coming soon!)
-<!-- 
-- Convert a PDF file to a text file using the `pdf_to_txt` command
-- Convert PDF files to multiple text files when too long
-    - This may be useful when you want to read the converted text file with Auto-GPT, to avoid the limitation of the number of tokens -->
+- env file system better and easy to edit. 
+- alert system when intering invalid model of gpt.
 
 ## Installation:
 As part of the AutoGPT plugins package, follow the [installation instructions](https://github.com/Significant-Gravitas/Auto-GPT-Plugins) on the Auto-GPT-Plugins GitHub reporistory README page.
@@ -20,3 +18,4 @@ As part of the AutoGPT plugins package, follow the [installation instructions](h
 Set `ALLOWLISTED_PLUGINS=autogpt-api-tools,example-plugin1,example-plugin2,etc` in your AutoGPT `.env` file.
 
 ## Additional tips.
+system input of gpt is set to "summarizing" purpose. If you edit the system, then you can make it have a differnt function.(gpt4.py chat_completion())

--- a/src/autogpt_plugins/gpt4/README.md
+++ b/src/autogpt_plugins/gpt4/README.md
@@ -1,0 +1,16 @@
+# Plugin for PDF to Text
+
+## Features(more coming soon!)
+<!-- 
+- Convert a PDF file to a text file using the `pdf_to_txt` command
+- Convert PDF files to multiple text files when too long
+    - This may be useful when you want to read the converted text file with Auto-GPT, to avoid the limitation of the number of tokens -->
+
+## Installation:
+As part of the AutoGPT plugins package, follow the [installation instructions](https://github.com/Significant-Gravitas/Auto-GPT-Plugins) on the Auto-GPT-Plugins GitHub reporistory README page.
+
+## AutoGPT Configuration
+Set `ALLOWLISTED_PLUGINS=autogpt-api-tools,example-plugin1,example-plugin2,etc` in your AutoGPT `.env` file.
+
+## Additional tips.
+<!-- one chunk is set to 4000 tokens. When you use gpt-3.5 4000 maximum token, you should edit varriable "one_chunk" in pdf_to_txt.py. -->

--- a/src/autogpt_plugins/gpt4/README.md
+++ b/src/autogpt_plugins/gpt4/README.md
@@ -20,4 +20,3 @@ As part of the AutoGPT plugins package, follow the [installation instructions](h
 Set `ALLOWLISTED_PLUGINS=autogpt-api-tools,example-plugin1,example-plugin2,etc` in your AutoGPT `.env` file.
 
 ## Additional tips.
-<!-- one chunk is set to 4000 tokens. When you use gpt-3.5 4000 maximum token, you should edit varriable "one_chunk" in pdf_to_txt.py. -->

--- a/src/autogpt_plugins/gpt4/__init__.py
+++ b/src/autogpt_plugins/gpt4/__init__.py
@@ -1,0 +1,214 @@
+"""This is the gpt4 plugin for AutoGPT."""
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, TypeVar
+from auto_gpt_plugin_template import AutoGPTPluginTemplate
+from .gpt4 import GPT4
+
+PromptGenerator = TypeVar("PromptGenerator")
+
+
+class Message(TypedDict):
+    role: str
+    content: str
+
+
+class AutoGPTgpt4(AutoGPTPluginTemplate):
+    """
+    use customized gpt4
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._name = "autogpt-gpt4-plugin"
+        self._version = "0.1.0"
+        self._description = "use customized gpt4"
+
+    def can_handle_on_response(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the on_response method.
+        Returns:
+            bool: True if the plugin can handle the on_response method."""
+        return False
+
+    def on_response(self, response: str, *args, **kwargs) -> str:
+        """This method is called when a response is received from the model."""
+        pass
+
+    def can_handle_post_prompt(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the post_prompt method.
+        Returns:
+            bool: True if the plugin can handle the post_prompt method."""
+        return True
+
+    def can_handle_on_planning(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the on_planning method.
+        Returns:
+            bool: True if the plugin can handle the on_planning method."""
+        return False
+
+    def on_planning(
+        self, prompt: PromptGenerator, messages: List[str]
+    ) -> Optional[str]:
+        """This method is called before the planning chat completeion is done.
+        Args:
+            prompt (PromptGenerator): The prompt generator.
+            messages (List[str]): The list of messages.
+        """
+        pass
+
+    def can_handle_post_planning(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the post_planning method.
+        Returns:
+            bool: True if the plugin can handle the post_planning method."""
+        return False
+
+    def post_planning(self, response: str) -> str:
+        """This method is called after the planning chat completeion is done.
+        Args:
+            response (str): The response.
+        Returns:
+            str: The resulting response.
+        """
+        pass
+
+    def can_handle_pre_instruction(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the pre_instruction method.
+        Returns:
+            bool: True if the plugin can handle the pre_instruction method."""
+        return False
+
+    def pre_instruction(self, messages: List[str]) -> List[str]:
+        """This method is called before the instruction chat is done.
+        Args:
+            messages (List[str]): The list of context messages.
+        Returns:
+            List[str]: The resulting list of messages.
+        """
+        pass
+
+    def can_handle_on_instruction(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the on_instruction method.
+        Returns:
+            bool: True if the plugin can handle the on_instruction method."""
+        return False
+
+    def on_instruction(self, messages: List[str]) -> Optional[str]:
+        """This method is called when the instruction chat is done.
+        Args:
+            messages (List[str]): The list of context messages.
+        Returns:
+            Optional[str]: The resulting message.
+        """
+        pass
+
+    def can_handle_post_instruction(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the post_instruction method.
+        Returns:
+            bool: True if the plugin can handle the post_instruction method."""
+        return False
+
+    def post_instruction(self, response: str) -> str:
+        """This method is called after the instruction chat is done.
+        Args:
+            response (str): The response.
+        Returns:
+            str: The resulting response.
+        """
+        pass
+
+    def can_handle_pre_command(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the pre_command method.
+        Returns:
+            bool: True if the plugin can handle the pre_command method."""
+        return False
+
+    def pre_command(
+        self, command_name: str, arguments: Dict[str, Any]
+    ) -> Tuple[str, Dict[str, Any]]:
+        """This method is called before the command is executed.
+        Args:
+            command_name (str): The command name.
+            arguments (Dict[str, Any]): The arguments.
+        Returns:
+            Tuple[str, Dict[str, Any]]: The command name and the arguments.
+        """
+        pass
+
+    def can_handle_post_command(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the post_command method.
+        Returns:
+            bool: True if the plugin can handle the post_command method."""
+        return False
+
+    def post_command(self, command_name: str, response: str) -> str:
+        """This method is called after the command is executed.
+        Args:
+            command_name (str): The command name.
+            response (str): The response.
+        Returns:
+            str: The resulting response.
+        """
+        pass
+
+    def can_handle_chat_completion(
+        self,
+        messages: list[Dict[Any, Any]],
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> bool:
+        """This method is called to check that the plugin can
+        handle the chat_completion method.
+        Args:
+            messages (Dict[Any, Any]): The messages.
+            model (str): The model name.
+            temperature (float): The temperature.
+            max_tokens (int): The max tokens.
+        Returns:
+            bool: True if the plugin can handle the chat_completion method."""
+        return False
+
+    def handle_chat_completion(
+        self,
+        messages: list[Dict[Any, Any]],
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        """This method is called when the chat completion is done.
+        Args:
+            messages (Dict[Any, Any]): The messages.
+            model (str): The model name.
+            temperature (float): The temperature.
+            max_tokens (int): The max tokens.
+        Returns:
+            str: The resulting response.
+        """
+        return None
+
+    def post_prompt(self, prompt: PromptGenerator) -> PromptGenerator:
+        """This method is called just after the generate_prompt is called,
+            but actually before the prompt is generated.
+        Args:
+            prompt (PromptGenerator): The prompt generator.
+        Returns:
+            PromptGenerator: The prompt generator.
+        """
+
+        prompt.add_command(
+            "input text",
+            "input_text",
+            {
+                "input_text": "<text>"
+            },
+            chat_completion
+        )
+
+        return prompt

--- a/src/autogpt_plugins/gpt4/__init__.py
+++ b/src/autogpt_plugins/gpt4/__init__.py
@@ -202,13 +202,16 @@ class AutoGPTgpt4(AutoGPTPluginTemplate):
             PromptGenerator: The prompt generator.
         """
 
+        from .gpt4 import GPT4
+        gpt4 = GPT4()
+
         prompt.add_command(
-            "input text",
-            "input_text",
+            "use_gpt4",
+            "use gpt4",
             {
                 "input_text": "<text>"
             },
-            chat_completion
+            gpt4.chat_completion
         )
 
         return prompt

--- a/src/autogpt_plugins/gpt4/gpt4.py
+++ b/src/autogpt_plugins/gpt4/gpt4.py
@@ -1,0 +1,29 @@
+import os
+import openai
+from dotenv import load_dotenv
+
+load_dotenv('.env.plugin')
+
+class GPT4:
+    def __init__(self):
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("OPENAI_API_KEY environment variable not set.")
+        openai.api_key = self.api_key
+        self.model = os.getenv("GPT_MODEL", "text-davinci-002")  # Default to "text-davinci-002" if GPT_MODEL is not set
+        self.temperature = os.getenv("temperature")
+        print(self.model)
+        self.prompt = [
+            {"role": "system", "content": "you are a PDF summerizer. you are heading to a goal to summerize 1 paper devided in 4 because of the length."},
+            {"role": "system", "content": "summerize the paper."}
+        ]
+
+    def chat_completion(self, message):
+        message = {"role": "user", "content": message}
+        self.prompt.append(message)
+        response = openai.ChatCompletion.create(model=self.model, messages=self.prompt, temperature = self.temperature, max_tokens = 2000)
+        answer = response['choices'][0]['message']['content']
+        token = response['usage']['total_tokens']
+        self.prompt.append({"role": "assistant", "content": answer})
+        # answer = [answer, token]
+        return answer

--- a/src/autogpt_plugins/gpt4/gpt4.py
+++ b/src/autogpt_plugins/gpt4/gpt4.py
@@ -2,7 +2,7 @@ import os
 import openai
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv('plugins/Auto-GPT-use-gpt4-plugin/src/autogpt_plugins/gpt4.env')
 
 class GPT4:
     def __init__(self):
@@ -18,8 +18,8 @@ class GPT4:
             {"role": "system", "content": "summerize the paper."}
         ]
 
-    def chat_completion(self, message):
-        message = {"role": "user", "content": message}
+    def chat_completion(self, input_text: str):
+        message = {"role": "user", "content": input_text}
         self.prompt.append(message)
         response = openai.ChatCompletion.create(model=self.model, messages=self.prompt, temperature = self.temperature, max_tokens = 2000)
         answer = response['choices'][0]['message']['content']

--- a/src/autogpt_plugins/gpt4/gpt4.py
+++ b/src/autogpt_plugins/gpt4/gpt4.py
@@ -2,15 +2,15 @@ import os
 import openai
 from dotenv import load_dotenv
 
-load_dotenv('.env.plugin')
+load_dotenv()
 
 class GPT4:
     def __init__(self):
-        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.api_key = os.getenv("OPENAI_API_KEY_PLUGIN")
         if not self.api_key:
-            raise ValueError("OPENAI_API_KEY environment variable not set.")
+            raise ValueError("OPENAI_API_KEY_PLUGIN environment variable not set.")
         openai.api_key = self.api_key
-        self.model = os.getenv("GPT_MODEL", "text-davinci-002")  # Default to "text-davinci-002" if GPT_MODEL is not set
+        self.model = os.getenv("GPT_MODEL_PLUGIN", "gpt-4")  # Default to "gpt-4" if GPT_MODEL is not set
         self.temperature = os.getenv("temperature")
         print(self.model)
         self.prompt = [


### PR DESCRIPTION
## gpt4-plugin プログラムの目的
### txtファイル要約課題
autogptにはテキストを直接要約する機能が備わってない。類似する名前を持つコマンド "get_text_summary"は引数としてURLを求めており、webページの要約のみを可能としている。したがって、現在のautogptでtxtファイルを要約するような指示は不毛なループにつながる。

### gptコマンドの必要性
また、別の課題としてautogptを動かしている根幹であるgptはtemperature 0で稼働しており、自由な発想や記述についてgpt本来の能力を発揮していない。そして、コマンドやautogptのメインループ以外で自由な入力を受け付けて出力する機能はない。

簡易的な解決方法としてgptを使用するコマンドを提案する。

## 破壊的変更をもたらしますか
[X] Yes
[ ] No

## Pull Request の種類
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:

## 検証方法
### コードの検証
ai_settings.yaml
```
ai_goals:
- use command use_gpt4 to summarize this paper1_chunk_0.txt autogpt/auto_gpt_workspace/paper1 this relative directory.
- export the summary to text file.
ai_name: summarizer
ai_role: an agent to summarize long text
api_budget: 0.0
```

## 今後の課題
[ ] gpt4.pyにおいて、load_dotenv(‘plugins/Auto-GPT-use-gpt4-plugin/src/autogpt_plugins/gpt4.env’) で.envファイルを読み込むために絶対パスを書いているが、本家のプライグインの配置が変更されると不動になるため、改善した方が良い。
[ ] .envファイルでのOPEN_AI_KEYとMODELセットアップ方法を工夫した方がいいと思う。良い例がplanner plugin(https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/planner)にある。
[ ] MODELの名前を間違えたらアラートしてデフォルトのgptモデルで実行されるなどのセーフな設計にした方が良い。